### PR TITLE
Show Mouse Events Setting and Crash Fixes

### DIFF
--- a/src/screencastkeys/__init__.py
+++ b/src/screencastkeys/__init__.py
@@ -22,7 +22,7 @@
 bl_info = {
     'name': 'Screencast Keys',
     'author': 'Paulo Gomes, Bart Crouch, John E. Herrenyo, '
-              'Gaia Clary, Pablo Vazquez, chromoly, Nutti',
+              'Gaia Clary, Pablo Vazquez, chromoly, Hawkpath, Nutti',
     'version': (3, 0, 0),
     'blender': (2, 80, 0),
     'location': '3D View > Properties Panel > Screencast Keys',

--- a/src/screencastkeys/ops.py
+++ b/src/screencastkeys/ops.py
@@ -611,6 +611,8 @@ class ScreencastKeysStatus(bpy.types.Operator):
         if not self.__class__.running:
             return {'FINISHED'}
 
+        if event.type == '':
+            return {'PASS_THROUGH'}
         event_type = EventType[event.type]
         current_time = time.time()
 

--- a/src/screencastkeys/ops.py
+++ b/src/screencastkeys/ops.py
@@ -196,10 +196,6 @@ class ScreencastKeysStatus(bpy.types.Operator):
         EventType.BUTTON5MOUSE,  # Button5 Mouse
         EventType.BUTTON6MOUSE,  # Button6 Mouse
         EventType.BUTTON7MOUSE,  # Button7 Mouse
-        # EventType.PEN,  # Pen
-        # EventType.ERASER,  # Eraser
-        # EventType.MOUSEMOVE,  # Mouse Move
-        # EventType.INBETWEEN_MOUSEMOVE,  # In-between Move
         EventType.TRACKPADPAN,  # Mouse/Trackpad Pan
         EventType.TRACKPADZOOM,  # Mouse/Trackpad Zoom
         EventType.MOUSEROTATE,  # Mouse/Trackpad Rotate
@@ -612,6 +608,9 @@ class ScreencastKeysStatus(bpy.types.Operator):
             return {'FINISHED'}
 
         if event.type == '':
+            # Many events that should (?) be identified as 'NONE' instead are
+            # identified as '' and raise KeyErrors in EventType
+            # (i.e. caps lock and the spin tool in edit mode)
             return {'PASS_THROUGH'}
         event_type = EventType[event.type]
         current_time = time.time()

--- a/src/screencastkeys/preferences.py
+++ b/src/screencastkeys/preferences.py
@@ -120,6 +120,10 @@ class ScreenCastKeysPreferences(bpy.types.AddonPreferences):
         step=10,
         subtype='TIME'
     )
+    show_mouse_events = bpy.props.BoolProperty(
+        name='Show Mouse Events',
+        default=True,
+    )
     show_last_operator = bpy.props.BoolProperty(
         name='Show Last Operator',
         default=False,
@@ -164,6 +168,7 @@ class ScreenCastKeysPreferences(bpy.types.AddonPreferences):
             col = split.column()
             col.prop(self, 'origin')
             col.prop(self, 'offset')
+            col.prop(self, 'show_mouse_events')
             col.prop(self, 'show_last_operator')
 
             self.layout.separator()


### PR DESCRIPTION
**Purpose of the pull request**  
Feature addition


**Description about the pull request**  
I added a setting to allow users to toggle whether mouse events appear. I found that they were too obtrusive and wouldn't add any benefit in situations such as while teaching an already-experienced class.


**Additional comments** [Optional]  
I also made the name of show_last_operator in the 3D viewport panel consistent with what it's called in the preferences.