### PR TITLE
bug fix - detect console mode using bpy.app.background

### DIFF
--- a/src/screencast_keys/common.py
+++ b/src/screencast_keys/common.py
@@ -38,6 +38,8 @@ CUSTOM_MOUSE_IMG_MMOUSE_NAME = \
 
 
 def is_console_mode():
+    if bpy.app.background:
+        return True
     if "SK_CONSOLE_MODE" not in os.environ:
         return False
     return os.environ["SK_CONSOLE_MODE"] == "true"


### PR DESCRIPTION
Resolves errors like below on `register()` if blender is currently in background mode:

```
Exception in module register(): \Blender\4.2\extensions\blender_org\screencast_keys\__init__.py
Traceback (most recent call last):
  File "\Blender\4.2\scripts\modules\addon_utils.py", line 482, in enable
    mod.register()
  File "\Blender\4.2\extensions\blender_org\screencast_keys\__init__.py", line 135, in register
    gpu_utils.shader.ShaderManager.register_shaders()
  File "\Blender\4.2\extensions\blender_org\screencast_keys\gpu_utils\shader.py", line 52, in register_shaders
    gpu.platform.backend_type_get() != 'OPENGL':
```

